### PR TITLE
Import with a single statement in "How it Works"

### DIFF
--- a/_source/handbook/02_how_it_works.md
+++ b/_source/handbook/02_how_it_works.md
@@ -74,8 +74,7 @@ The basic `"form"` component is now created we can send a `message` to a corresp
 ```javascript
 // bridge/form_controller.js
 
-import { BridgeComponent } from "@hotwired/strada"
-import { BridgeElement } from "@hotwired/strada"
+import { BridgeComponent, BridgeElement } from "@hotwired/strada"
 
 export default class extends BridgeComponent {
   static component = "form"

--- a/_source/reference/components.md
+++ b/_source/reference/components.md
@@ -42,8 +42,7 @@ Create a `BridgeComponent` with the `"form"` name that sends a message to the na
 ```javascript
 // bridge/form_controller.js
 
-import { BridgeComponent } from "@hotwired/strada"
-import { BridgeElement } from "@hotwired/strada"
+import { BridgeComponent, BridgeElement } from "@hotwired/strada"
 
 export default class extends BridgeComponent {
   static component = "form"


### PR DESCRIPTION
The `BridgeComponent` and `BridgeElement` are imported from the same package name, so they should appear in the same `import` declaration.