### PR TITLE
Use Target Callbacks in "How it Works" example

### DIFF
--- a/_source/handbook/02_how_it_works.md
+++ b/_source/handbook/02_how_it_works.md
@@ -81,17 +81,12 @@ export default class extends BridgeComponent {
   static component = "form"
   static targets = [ "submit" ]
 
-  connect() {
-    super.connect()
-    this.notifyBridgeOfConnect()
-  }
-
-  notifyBridgeOfConnect() {
-    const submitButton = new BridgeElement(this.submitTarget)
+  submitTargetConnected(target) {
+    const submitButton = new BridgeElement(target)
     const submitTitle = submitButton.title
 
     this.send("connect", { submitTitle }, () => {
-      this.submitTarget.click()
+      target.click()
     })
   }
 }

--- a/_source/reference/components.md
+++ b/_source/reference/components.md
@@ -49,17 +49,12 @@ export default class extends BridgeComponent {
   static component = "form"
   static targets = [ "submit" ]
 
-  connect() {
-    super.connect()
-    this.notifyBridgeOfConnect()
-  }
-
-  notifyBridgeOfConnect() {
-    const submitButton = new BridgeElement(this.submitTarget)
+  submitTargetConnected(target) {
+    const submitButton = new BridgeElement(target)
     const submitTitle = submitButton.title
 
     this.send("connect", { submitTitle }, () => {
-      this.submitTarget.click()
+      target.click()
     })
   }
 }


### PR DESCRIPTION
Replace the `connect()` hook with a `submitTargetConnected(target)` [Target Callback][] hook declaration.

As an alternative to `connect()`, the target callback does not require a call to a `super.`-prefixed method, and the
`[data-bridge--form-target="submit"]` element is provided as an argument.

[Target Callback]: https://stimulus.hotwired.dev/reference/targets#connected-and-disconnected-callbacks