### PR TITLE
Expand the installation instructions

### DIFF
--- a/_source/handbook/06_installing.md
+++ b/_source/handbook/06_installing.md
@@ -36,20 +36,12 @@ Alternatively, you can manually define importmap entries for both Strada and Sti
 
 Then you can import Strada anywhere in your application code:
 
-```html
-  <script type="module">
-    import { Application } from "@hotwired/stimulus"
+```js
     import { BridgeComponent } from "@hotwired/strada"
-
-    const application = Application.start()
-    window.Stimulus = application
 
     class BridgeTest extends BridgeComponent {
       // ...
     }
-
-    application.register("bridge-test", BridgeTest)
-  </script>
 ```
 
 ## As An npm Package

--- a/_source/handbook/06_installing.md
+++ b/_source/handbook/06_installing.md
@@ -13,11 +13,48 @@ Strada leverages [Stimulus](https://stimulus.hotwired.dev) and the core `BridgeC
 
 ## In Compiled Form
 
-You can float on the latest release of Strada using a CDN bundler or import <a href="https://unpkg.com/@hotwired/strada/dist/strada.js">strada.js</a> using a `<script type="module">` tag.
+If you're using [importmap-rails](https://github.com/rails/importmap-rails) you just need to pin Stimulus and Strada in your config/importmap.rb file:
+
+```sh
+./bin/importmap pin @hotwired/stimulus @hotwired/strada
+```
+
+Alternatively, you can manually define importmap entries for both Strada and Stimulus, pointing to the latest versions of each:
+
+```html
+<head>
+  <script type="importmap">
+    {
+      "imports": {
+        "@hotwired/stimulus": "https://cdn.jsdelivr.net/npm/@hotwired/stimulus@latest/dist/stimulus.min.js",
+        "@hotwired/strada": "https://cdn.jsdelivr.net/npm/@hotwired/strada@latest/dist/strada.min.js"
+      }
+    }
+  </script>
+</head>
+```
+
+Then you can import Strada anywhere in your application code:
+
+```html
+  <script type="module">
+    import { Application } from "@hotwired/stimulus"
+    import { BridgeComponent } from "@hotwired/strada"
+
+    const application = Application.start()
+    window.Stimulus = application
+
+    class BridgeTest extends BridgeComponent {
+      // ...
+    }
+
+    application.register("bridge-test", BridgeTest)
+  </script>
+```
 
 ## As An npm Package
 
-You can install Strada from npm via the `npm` or `yarn` packaging tools. Then require or import that in your code:
+You can install Strada from npm via the `npm` or `yarn` packaging tools and use a JavaScript bundler, like webpack or esbuild, to import it in your application.
 
 ```javascript
 import "@hotwired/strada"


### PR DESCRIPTION
Since strada-web depends on Stimulus and imports "@hotwired/stimulus" in its own source code, we need to make sure that the import is available.

The easiest way to do this is to use importmap-rails, which will automatically add the importmap script tag to your layout. If you're not using importmap-rails, you can manually add the importmap script tag to your layout, or use a JS bundler such as Webpack or esbuild.